### PR TITLE
tailing and heading spaces in crt removed

### DIFF
--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"bytes"
 )
 
 // TLSPrivateKeyPassword is the environment variable which contains the password used
@@ -38,6 +39,9 @@ func parsePublicCertFile(certFile string) (x509Certs []*x509.Certificate, err er
 	if data, err = ioutil.ReadFile(certFile); err != nil {
 		return nil, err
 	}
+
+	//Trimming leading and tailing spaces
+	data = bytes.TrimSpace(data)
 
 	// Parse all certs in the chain.
 	current := data


### PR DESCRIPTION

Issue Fix: **SSL - Invalid SSL certificate file #5632**

The spaces in the public.crt throws "Invalid SSL certificate file"

Changes Done: Removed the tailing/heading spaces in **parsePublicCertFile** function

